### PR TITLE
fix: set default path to FileName.appDir

### DIFF
--- a/KartRider.Data/Program.cs
+++ b/KartRider.Data/Program.cs
@@ -86,16 +86,12 @@ namespace KartRider
                 if (args == null || args.Length == 0)
                 {
                     string TCGame = "HKEY_CURRENT_USER\\SOFTWARE\\TCGame\\kart";
-                    string RootDirectory = Path.GetFullPath((string)Registry.GetValue(TCGame, "gamepath", null));
+                    string RootDirectory = Path.GetFullPath((string)Registry.GetValue(TCGame, "gamepath", FileName.appDir));
                     if (File.Exists(FileName.pinFile) && File.Exists(FileName.KartRider))
                     {
                         RootDirectory = FileName.appDir;
                     }
-                    else if (File.Exists(Path.GetFullPath(Path.Combine(RootDirectory, @"KartRider.pin"))) && File.Exists(Path.GetFullPath(Path.Combine(RootDirectory, @"KartRider.exe"))))
-                    {
-                        RootDirectory = (string)Registry.GetValue(TCGame, "gamepath", null);
-                    }
-                    else
+                    else if (!(File.Exists(Path.GetFullPath(Path.Combine(RootDirectory, @"KartRider.pin"))) && File.Exists(Path.GetFullPath(Path.Combine(RootDirectory, @"KartRider.exe")))))
                     {
                         LauncherSystem.MessageBoxType3();
                         return;


### PR DESCRIPTION
<!-- 

Thanks for your contribution!

tips: most PRs need an issue number, except some trivial changes, like fixing a typo, do not need issue. so please make sure you have an issue before you create a PR.

非常感谢你对启动器的贡献！

提示：大多数的PR需要issue编号，除了修复拼写错误等一些琐碎的改动不需要issue。所以，请确保你在创建PR之前已经有一个issue。 

-->

# Pull Request

## PR 类型 / PR Type

- [ ] 新功能 / Feature
- [x] 修复 Bug / Bug Fix
- [ ] 文档更新 / Documentation
- [ ] 优化/重构 / Refactor
- [ ] 杂项：拼写，统一码风等 / Chore
- [ ] 其他，请说明类型 / Other

## 变更内容简述 / Description

把游戏的默认路径从 `null` 修改为 `FileName.appDir`。
这样如果没有安装 TCGAME，则把将默认路径直接设为 CWD。

## 相关 Issue（如有）/ Related Issue (if any)

fix (#17)

## 测试说明 / Test Instructions

- [x] 已本地测试 / Tested locally
- [ ] 需要帮忙测试 / Test Needed

<!-- 如果是文档修改，则无需勾选 / No need to check if it is a documentation change -->

## 其他补充说明 / Additional Notes

无

<!-- 需要特别说明的内容、注意事项等 / Any additional notes or special instructions -->
