### PR TITLE
refactor(Mod系统): 添加服务注册表与Mod生命周期事件

### DIFF
--- a/KartRider.Data/Mod/ModManager.cs
+++ b/KartRider.Data/Mod/ModManager.cs
@@ -20,6 +20,10 @@ public static class ModManager
     private static string ModPath { get; set; } = string.Empty;
 
     public static event Action OnAllModLoaded;
+    public static event Action<string> OnModLoaded;
+    public static event Action<string> OnModUnloaded;
+    public static event Action<string> OnModReloading;
+    public static event Action<string> OnModReloaded;
 
     public static void Initialize(string RootDirectory)
     {
@@ -34,7 +38,14 @@ public static class ModManager
         LoadMods(ModPath);
         Console.WriteLine($"Mod加载完成，共加载 {ModList.Count} 个 Mod。");
 
-        OnAllModLoaded?.Invoke();
+        try
+        {
+            OnAllModLoaded?.Invoke();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[错误] OnAllModLoaded 事件处理程序抛出异常: {ex.Message}");
+        }
     }
 
     public static void LoadMods(string modPath)
@@ -138,11 +149,24 @@ public static class ModManager
                 IsPacketHandler = isPacketHandler
             });
 
+            // 所有 Mod 按名称自动注册到 ServiceRegistry
+            // 依赖 Mod 也会注册，消费者统一通过 ServiceRegistry.Invoke 调用
+            ServiceRegistry.Register(mod.Name, mod);
+
             Console.WriteLine(
                 $">>> 成功加载 Mod: [{mod.Name}] 来自 {Path.GetFileName(filePath)}"
             );
             Console.WriteLine("Mod描述:" + mod.Description);
             Console.WriteLine("Mod版本:" + mod.Version);
+
+            try
+            {
+                OnModLoaded?.Invoke(mod.Name);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[错误] OnModLoaded 事件处理程序抛出异常: {ex.Message}");
+            }
 
             return true;
         }
@@ -178,6 +202,10 @@ public static class ModManager
             }
 
             ModList.Remove(modInfo);
+
+            // 从 ServiceRegistry 移除注册
+            ServiceRegistry.Unregister(modInfo.Instance.Name);
+
             modInfo.LoadContext.Unload();
 
             modInfo.Instance = null;
@@ -187,6 +215,16 @@ public static class ModManager
             GC.WaitForPendingFinalizers();
 
             Console.WriteLine($">>> 成功卸载 Mod: [{modName}]");
+
+            try
+            {
+                OnModUnloaded?.Invoke(modName);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[错误] OnModUnloaded 事件处理程序抛出异常: {ex.Message}");
+            }
+
             return true;
         }
         catch (Exception ex)
@@ -207,12 +245,35 @@ public static class ModManager
 
         string filePath = modInfo.FilePath;
 
+        try
+        {
+            OnModReloading?.Invoke(modName);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[错误] OnModReloading 事件处理程序抛出异常: {ex.Message}");
+        }
+
         if (!UnloadMod(modName))
         {
             return false;
         }
 
-        return LoadMod(filePath);
+        if (!LoadMod(filePath))
+        {
+            return false;
+        }
+
+        try
+        {
+            OnModReloaded?.Invoke(modName);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[错误] OnModReloaded 事件处理程序抛出异常: {ex.Message}");
+        }
+
+        return true;
     }
 
     public static void UnloadAllMods()

--- a/KartRider.Data/Mod/ServiceRegistry.cs
+++ b/KartRider.Data/Mod/ServiceRegistry.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace KartRider;
+
+/// <summary>
+/// 服务注册表，实现 Mod 间通过字符串名称解耦调用。
+/// 
+/// 设计原则：
+/// - 按字符串名称注册，内部使用 WeakReference 避免阻挠 Assembly 卸载
+/// - 消费方不引用提供方的 DLL，完全解耦
+/// - 热加载时旧实例自动释放，新实例注册后立即生效
+/// 
+/// 使用方式：
+///   // 提供方在 OnInitialize 中注册
+///   ServiceRegistry.Register("DatabaseProvider", this);
+///   
+///   // 消费方获取实例（自行反射调用）
+///   var db = ServiceRegistry.GetService("DatabaseProvider");
+///   var method = db.GetType().GetMethod("Query");
+///   var table = method.Invoke(db, new object[] { sql, parameters });
+///   
+///   // 或一步到位
+///   var table = ServiceRegistry.Invoke("DatabaseProvider", "Query", sql, parameters);
+/// </summary>
+public static class ServiceRegistry
+{
+    // 按名称存储的弱引用字典
+    private static readonly Dictionary<string, WeakReference> _services = new(StringComparer.OrdinalIgnoreCase);
+
+    // 用于方法查找的缓存（MethodInfo 不持有实例引用，可以安全缓存）
+    private static readonly Dictionary<string, MethodInfo> _methodCache = new();
+
+    /// <summary>
+    /// 注册服务实例（按名称，内部用弱引用）
+    /// </summary>
+    public static void Register(string name, object instance)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("服务名称不能为空", nameof(name));
+        if (instance == null)
+            throw new ArgumentNullException(nameof(instance));
+
+        _services[name] = new WeakReference(instance);
+    }
+
+    /// <summary>
+    /// 按名称获取服务实例（返回 object?，需要调用方自行转型）
+    /// </summary>
+    public static object? GetService(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return null;
+
+        if (_services.TryGetValue(name, out var wr))
+        {
+            var instance = wr.Target;
+            if (instance != null)
+                return instance;
+
+            // 弱引用已失效，清理
+            _services.Remove(name);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// 一步调用：按名称获取服务实例并调用其方法。
+    /// 内部缓存 MethodInfo 以减少反射开销。
+    /// </summary>
+    /// <param name="name">服务注册名</param>
+    /// <param name="methodName">方法名</param>
+    /// <param name="args">调用参数</param>
+    /// <returns>方法返回值，若服务不存在返回 null</returns>
+    public static object? Invoke(string name, string methodName, params object?[]? args)
+    {
+        var instance = GetService(name);
+        if (instance == null)
+            return null;
+
+        var type = instance.GetType();
+        var cacheKey = $"{type.GUID}:{methodName}";
+
+        if (!_methodCache.TryGetValue(cacheKey, out var method))
+        {
+            method = type.GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance);
+            if (method == null)
+                throw new MissingMethodException($"类型 {type.FullName} 中找不到方法 {methodName}");
+            _methodCache[cacheKey] = method;
+        }
+
+        return method.Invoke(instance, args);
+    }
+
+    /// <summary>
+    /// 移除注册（ModManager 卸载 Mod 时调用）
+    /// </summary>
+    public static void Unregister(string name)
+    {
+        if (!string.IsNullOrWhiteSpace(name))
+            _services.Remove(name);
+    }
+
+    /// <summary>
+    /// 检查服务是否已注册且可用
+    /// </summary>
+    public static bool IsRegistered(string name)
+    {
+        return GetService(name) != null;
+    }
+}


### PR DESCRIPTION
新增ServiceRegistry实现跨Mod解耦的服务注册调用能力，同时为ModManager添加完整的加载/卸载/重载生命周期事件，并在事件调用时捕获异常避免因单个事件处理器出错导致整体流程中断

ServiceRegistry使用了弱引用,让mod热加载时之前的mod实例可以顺利被销毁.